### PR TITLE
Fix breadcrumb JSON-LD double-encoding (invalid URL in structured data)

### DIFF
--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -9,27 +9,27 @@
       "@type": "ListItem",
       "position": 1,
       "name": "Home",
-      "item": {{ site.BaseURL | jsonify }}
+      "item": "{{ site.BaseURL }}"
     }
     {{- if and .IsPage .CurrentSection (not .CurrentSection.IsHome) -}}
     ,{
       "@type": "ListItem",
       "position": 2,
-      "name": {{ .CurrentSection.Title | jsonify }},
-      "item": {{ .CurrentSection.Permalink | jsonify }}
+      "name": "{{ .CurrentSection.Title }}",
+      "item": "{{ .CurrentSection.Permalink }}"
     },
     {
       "@type": "ListItem",
       "position": 3,
-      "name": {{ .Title | jsonify }},
-      "item": {{ .Permalink | jsonify }}
+      "name": "{{ .Title }}",
+      "item": "{{ .Permalink }}"
     }
     {{- else -}}
     ,{
       "@type": "ListItem",
       "position": 2,
-      "name": {{ .Title | jsonify }},
-      "item": {{ .Permalink | jsonify }}
+      "name": "{{ .Title }}",
+      "item": "{{ .Permalink }}"
     }
     {{- end }}
   ]


### PR DESCRIPTION
## Summary

- Removes `| jsonify` from all breadcrumb URL and name fields in `layouts/partials/custom_head.html`
- Hugo's `html/template` auto-escapes values inside `<script>` tags; piping through `jsonify` first caused double-encoding, producing literal quote characters inside the JSON string values (e.g. `"item": "\"https://adobe.mdsr.live/\""`)
- Fixes the Google Search Console warning: **Invalid URL in field 'id' (in 'itemListElement.item')**

**Before (broken):**
```json
"item": "\"https://adobe.mdsr.live/research/\""
```

**After (correct):**
```json
"item": "https://adobe.mdsr.live/research/"
```

## Test plan

- [ ] Build the site with `hugo --baseURL "https://adobe.mdsr.live/"` and inspect a subpage's `<script type="application/ld+json">` block to confirm URLs are clean
- [ ] Validate with Google's Rich Results Test or schema.org validator
- [ ] Confirm Google Search Console no longer reports breadcrumb structured data errors after re-crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)